### PR TITLE
feat: bump shopify to v1.3.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/MOHC-LTD/mockshopify
 go 1.16
 
 require (
-	github.com/MOHC-LTD/shopify v1.2.0
+	github.com/MOHC-LTD/shopify v1.3.0
 	github.com/golang/mock v1.5.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/MOHC-LTD/shopify v1.2.0 h1:tzfGoC+3dkSocOJZ5aGf+E5VcKQg1IfQTNZOfYjfEng=
 github.com/MOHC-LTD/shopify v1.2.0/go.mod h1:ZqEEOCrFlhlQxqxzpfE9lah5uvjiGQNvcGERxaTACPQ=
+github.com/MOHC-LTD/shopify v1.3.0 h1:Aid4nbI3y0CAOMryp6iWR31y8pM5mEUVzt2MTH46B0w=
+github.com/MOHC-LTD/shopify v1.3.0/go.mod h1:ZqEEOCrFlhlQxqxzpfE9lah5uvjiGQNvcGERxaTACPQ=
 github.com/golang/mock v1.5.0 h1:jlYHihg//f7RRwuPfptm04yp4s7O6Kw8EZiVYIGcH0g=
 github.com/golang/mock v1.5.0/go.mod h1:CWnOUgYIOo4TcNZ0wHX3YZCqsaM1I1Jvs6v3mP3KVu8=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=


### PR DESCRIPTION
to provide coverage for https://github.com/MOHC-LTD/shopify/pull/6